### PR TITLE
Update 1.1.2 => 1.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "macocci7/php-frequency-table",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "it's easy to use for creating frequency distribution tables.",
     "type": "library",
     "require": {

--- a/src/FrequencyTable.php
+++ b/src/FrequencyTable.php
@@ -490,7 +490,7 @@ class FrequencyTable
             'QuartileDeviation' => $this->getQuartileDeviation($this->getData()),
             'Classes' => $this->getClasses(),
             'Frequencies' => $this->getFrequencies(),
-            'FrequencyTable' => $this->show(['Mean'=>true,'STDOUT'=>false,'ReturnValue'=>true]),
+            'FrequencyTable' => $this->meanOn()->markdown(),
         ];
     }
 


### PR DESCRIPTION
bufix: parse() not to use show(), to use meanOn()->markdown()